### PR TITLE
Job run specific checkout and JUnit support

### DIFF
--- a/hooks/post-run.yml
+++ b/hooks/post-run.yml
@@ -1,44 +1,47 @@
 ---
-- name: Find the JUnit result files
+- name: Find the result file
   find:
-    paths: './ansible-testrunner/ansible/test/results/junit/'
-    # Incase there are multiple platforms being tested, only copy the one we are interestd in
-    patterns: '{{ platform }}_*.xml'
+    paths: './ansible-testrunner/{{ job_id }}/ansible/test/results/junit/'
     recurse: yes
   register: junit_files
   delegate_to: testrunner
 
 - name: Create temp directory
   file:
-    path: "{{ lookup('env', 'PWD') }}/junit-{{ job_id }}"
+    path: "{{ lookup('env', 'PWD') }}/{{ job_id }}/junit-fragments/"
     state: directory
 
 - name: Fetch JUnit results
   fetch:
     src: '{{ item.path }}'
-    dest: "{{ lookup('env', 'PWD') }}/junit-{{ job_id }}"
+    dest: "{{ lookup('env', 'PWD') }}/{{ job_id }}/junit-fragments/"
     flat: yes
     validate_checksum: no
   with_items: '{{ junit_files.files }}'
   delegate_to: testrunner
 
-- name: Combine JUnit results into single file
-  shell: "xunitmerge {{ lookup('env', 'PWD') }}/junit-{{ job_id }}/*.xml {{ lookup('env', 'PWD') }}/junit-{{ job_id }}.xml"
+# pip install xunitmerge
 
-- name: Upload the results to DCI
+- name: Combine JUnit results into single file
+  shell: "xunitmerge {{ lookup('env', 'PWD') }}/{{ job_id }}/junit-fragments/*.xml {{ lookup('env', 'PWD') }}/{{ job_id }}/junit.xml"
+
+- name: Upload the results
   dci_file:
     job_id: '{{ job_id }}'
-    path: "{{ lookup('env', 'PWD') }}/junit-{{ job_id }}.xml"
+    path: "{{ lookup('env', 'PWD') }}/{{ job_id }}/junit.xml"
     mime: 'application/junit'
     name: 'run_{{ platform }}_integration_tests'
 
-- name: Delete JUnit files
+- name: Cleanup checkout on remote
   file:
-    path: "{{ item }}"
+    path: "{{ lookup('env', 'PWD') }}/{{ job_id }}"
     state: absent
-  with_items:
-    - "{{ lookup('env', 'PWD') }}/junit-{{ job_id }}.xml"
-    - "{{ lookup('env', 'PWD') }}/junit-{{ job_id }}"
+
+- name: Cleanup temp JUnit files on testrunner
+  file:
+    path: "./ansible-testrunner/{{ job_id }}"
+    state: absent
+  delegate_to: testrunner
 
 - name: Explicitly fails if the test suite has a failure
   fail:

--- a/hooks/post-run.yml
+++ b/hooks/post-run.yml
@@ -1,35 +1,44 @@
 ---
-- name: Find the result file
+- name: Find the JUnit result files
   find:
-    paths: './ansible-testrunner/junit'
+    paths: './ansible-testrunner/ansible/test/results/junit/'
+    # Incase there are multiple platforms being tested, only copy the one we are interestd in
+    patterns: '{{ platform }}_*.xml'
     recurse: yes
-  register: junit_file
+  register: junit_files
   delegate_to: testrunner
 
-- name: Fetch Junit results
-  fetch:
-    src: '{{ junit_file.files[0]["path"] }}'
-    dest: "{{ lookup('env', 'PWD') }}/junit.xml"
-    flat: yes
-  delegate_to: testrunner
-
-- name: Cleanup the directories
+- name: Create temp directory
   file:
-    path: './ansible-testrunner/junit'
-    state: absent
+    path: "{{ lookup('env', 'PWD') }}/junit-{{ job_id }}"
+    state: directory
+
+- name: Fetch JUnit results
+  fetch:
+    src: '{{ item.path }}'
+    dest: "{{ lookup('env', 'PWD') }}/junit-{{ job_id }}"
+    flat: yes
+    validate_checksum: no
+  with_items: '{{ junit_files.files }}'
   delegate_to: testrunner
 
-- name: Upload the results
+- name: Combine JUnit results into single file
+  shell: "xunitmerge {{ lookup('env', 'PWD') }}/junit-{{ job_id }}/*.xml {{ lookup('env', 'PWD') }}/junit-{{ job_id }}.xml"
+
+- name: Upload the results to DCI
   dci_file:
     job_id: '{{ job_id }}'
-    path: 'junit.xml'
+    path: "{{ lookup('env', 'PWD') }}/junit-{{ job_id }}.xml"
     mime: 'application/junit'
     name: 'run_{{ platform }}_integration_tests'
 
-- name: Remove the junit file
+- name: Delete JUnit files
   file:
-    path: 'junit.xml'
+    path: "{{ item }}"
     state: absent
+  with_items:
+    - "{{ lookup('env', 'PWD') }}/junit-{{ job_id }}.xml"
+    - "{{ lookup('env', 'PWD') }}/junit-{{ job_id }}"
 
 - name: Explicitly fails if the test suite has a failure
   fail:

--- a/hooks/pre-run.yml
+++ b/hooks/pre-run.yml
@@ -1,4 +1,18 @@
 ---
-- name: echo pre-run
-  command: >
-    echo 'Nothing to do for the moment as we use a nodepool base node'
+# Only delete unit results related to this platforms, It's possible we could be running two platforms against this version of Ansible.
+
+- name: Find old JUnit results for this platform
+  find:
+    paths: './ansible-testrunner/ansible/test/results/junit/'
+    patterns: '{{ platform }}_*.xml'
+    recurse: yes
+  register: junit_files
+  delegate_to: testrunner
+
+- name: Delete old JUnit results for this platform
+  file:
+    path: '{{ item.path }}'
+    state: absent
+  with_items: '{{ junit_files.files }}'
+  delegate_to: testrunner
+

--- a/hooks/pre-run.yml
+++ b/hooks/pre-run.yml
@@ -1,18 +1,4 @@
 ---
-# Only delete unit results related to this platforms, It's possible we could be running two platforms against this version of Ansible.
-
-- name: Find old JUnit results for this platform
-  find:
-    paths: './ansible-testrunner/ansible/test/results/junit/'
-    patterns: '{{ platform }}_*.xml'
-    recurse: yes
-  register: junit_files
-  delegate_to: testrunner
-
-- name: Delete old JUnit results for this platform
-  file:
-    path: '{{ item.path }}'
-    state: absent
-  with_items: '{{ junit_files.files }}'
-  delegate_to: testrunner
-
+- name: echo pre-run
+  debug:
+    msg: 'Nothing to do for the moment as we use a nodepool base node'

--- a/hooks/running.yml
+++ b/hooks/running.yml
@@ -1,17 +1,17 @@
 ---
-- name: Removing previous version of ansible
+- name: Create working directory based on job_id
   file:
-    path: ./ansible-testrunner/ansible
-    state: absent
+    path: "./ansible-testrunner/{{ job_id }}"
+    state: directory
 
 - name: Clone the ansible version to test
   git:
     repo: 'centos@{{ agent_public_ip}}:{{ base_location}}/{{ ansible_commit }}/ansible'
-    dest: ./ansible-testrunner/ansible
+    dest: "./ansible-testrunner/{{ job_id }}/ansible"
     version: '{{ ansible_commit }}'
 
 - name: Run the integration test suite
-  shell: 'ansible/test/runner/ansible-test network-integration --continue-on-error --inventory /var/lib/nodepool/ansible-testrunner/inventory {{ platform }}_.* -v'
+  shell: '{{ job_id }}/ansible/test/runner/ansible-test network-integration --continue-on-error --inventory /var/lib/nodepool/ansible-testrunner/inventory {{ platform }}_.* -v'
   args:
     chdir: './ansible-testrunner'
   ignore_errors: True

--- a/playbook.yml
+++ b/playbook.yml
@@ -20,6 +20,13 @@
       set_fact:
         job_id: '{{ job_informations["job_id"] }}'
 
+# Ensure the job_id variable is available to all hosts
+- hosts: all !localhost
+  tasks:
+    - name: Set  global variables
+      set_fact:
+        job_id: "{{ hostvars['localhost']['job_id'] }}"
+
 
 # New state
 #


### PR DESCRIPTION
Collect and combine JUnit results

* Ansible checkout now go into `job_id` directory to prevent accidental clobbering or race conditions
* JUnit results go into `JOB_ID` directory
* Ensure that `JOB_ID` is available to all hosts


Ansible-test produces a JUnit file per test target. DCI requires them to
be combined together into a single XML file.

To prevent against two runs (against different platforms) clobbering the
results ensure we only look at a single platform.