### PR TITLE
Cleanup in teardown

### DIFF
--- a/hooks/post-run.yml
+++ b/hooks/post-run.yml
@@ -32,17 +32,6 @@
     mime: 'application/junit'
     name: 'run_{{ platform }}_integration_tests'
 
-- name: Cleanup checkout on remote
-  file:
-    path: "{{ lookup('env', 'PWD') }}/{{ job_id }}"
-    state: absent
-
-- name: Cleanup temp JUnit files on testrunner
-  file:
-    path: "./ansible-testrunner/{{ job_id }}"
-    state: absent
-  delegate_to: testrunner
-
 - name: Explicitly fails if the test suite has a failure
   fail:
     msg: 'The integration test suite exited with failures. Please check the log'

--- a/hooks/teardown.yml
+++ b/hooks/teardown.yml
@@ -1,4 +1,16 @@
 ---
+
+- name: Cleanup checkout on remote
+  file:
+    path: "{{ lookup('env', 'PWD') }}/{{ job_id }}"
+    state: absent
+
+- name: Cleanup temp JUnit files on testrunner
+  file:
+    path: "./ansible-testrunner/{{ job_id }}"
+    state: absent
+  delegate_to: testrunner
+
 - name: Delete the nodepool node for the specified platform
   shell: nodepool delete $(nodepool list | grep '.*{{ platform }}.*\sready\s.*\sunlocked\s.*' | awk '{ print $2 }')
   delegate_to: testrunner


### PR DESCRIPTION
Cleanup should be the first thing in `teardown` incase nodepool fails. This will avoid leaving files up on the disk.