### PR TITLE
fix file mode on dci-credentials.sh

### DIFF
--- a/dci-agent-setup/roles/setup_dci/tasks/main.yml
+++ b/dci-agent-setup/roles/setup_dci/tasks/main.yml
@@ -39,5 +39,5 @@
     dest: /etc/profile.d/dci_credentials.sh
     owner: root
     group: root
-    mode: 744
+    mode: 0744
   no_log: true


### PR DESCRIPTION
fix the file mode for the setup_dci role.