### PR TITLE
Handle multiple nodes deletion on teardown hook

### DIFF
--- a/hooks/teardown.yml
+++ b/hooks/teardown.yml
@@ -12,7 +12,7 @@
   delegate_to: testrunner
 
 - name: Delete the nodepool node for the specified platform
-  shell: nodepool list | tail -n +4 | head -n -1 | awk -F '|' '{if ($5 ~ /^ net/ && $12 == " ready " && $14 == " unlocked ") print $2}' | xargs -t -n1 -r nodepool delete
+  shell: nodepool list | tail -n +4 | head -n -1 | awk -F '|' '{if ($5 ~ /^ {{ platform }}/ && $12 == " ready " && $14 == " unlocked ") print $2}' | xargs -t -n1 -r nodepool delete
   delegate_to: testrunner
 
 - name: Wait for the new node to be ready and unlocked

--- a/hooks/teardown.yml
+++ b/hooks/teardown.yml
@@ -12,7 +12,7 @@
   delegate_to: testrunner
 
 - name: Delete the nodepool node for the specified platform
-  shell: nodepool delete $(nodepool list | grep '.*{{ platform }}.*\sready\s.*\sunlocked\s.*' | awk '{ print $2 }')
+  shell: nodepool list | tail -n +4 | head -n -1 | awk -F '|' '{if ($5 ~ /^ net/ && $12 == " ready " && $14 == " unlocked ") print $2}' | xargs -t -n1 -r nodepool delete
   delegate_to: testrunner
 
 - name: Wait for the new node to be ready and unlocked


### PR DESCRIPTION
We assumed we would have one node per platform, thus we just grepped
nodepool list and ran a nodepool delete on match.
However, on platform agnostic modules we will have [net] group with
multiple nodes, thus we need to catch 'net-' nodes and pipe that output
to a xargs nodepool delete.