### PR TITLE
Remove teardown from new phase block

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -45,9 +45,6 @@
     components: "{{ job_informations['components'] }}"
   tasks:
     - block:
-        # We ensure the platform against which we will run our test
-        # is always clean
-        - include: hooks/teardown.yml
         # This checks to see if the code for the most recent snapshot of the
         # topic has already been pulled. If it hasn't, it pulls the code
         # and saves it onto the agent somewhere.


### PR DESCRIPTION
We are deleting twice a node, before test run and after test run.
While this is fine for sanity, it's inefficient.
However, the real reason for removing this behaviour is because with
the inclusion of platform agnostic modules Nodepool cannot create
the multiple nodes with the current timeout. Increasing the timeout
to build all nodes would make the test runs even longer.