### PR TITLE
Display results number in slack notification

### DIFF
--- a/hooks/failure.yml
+++ b/hooks/failure.yml
@@ -1,8 +1,16 @@
 ---
+- name: Retrieve the job results
+  dci_job:
+    id: '{{ job_id }}'
+    embed:
+      - results
+  register: job_results
+  delegate_to: localhost
+
 - name: Send failure notification via Slask
   slack:
     token: '{{ slack_token }}'
-    msg: '<https://www.distributed-ci.io/#!/jobs/{{ job_id }}/results| [{{ topic }}][{{ platform }}] Failed test > @here'
+    msg: '<https://www.distributed-ci.io/#!/jobs/{{ job_id }}/results| [{{ topic }}][{{ platform }}] Failed test > @here Total: {{ job_results.job.results[0].total }} - Success {{ job_results.job.results[0].success }} - Skip {{ job_results.job.results[0].skips }} - Error {{ job_results.job.results[0].errors }} - Failure {{ job_results.job.results[0].failures }}'
     channel: '#core_networking_tests'
     parse: none
     color: danger

--- a/hooks/success.yml
+++ b/hooks/success.yml
@@ -1,8 +1,16 @@
 ---
+- name: Retrieve the job results
+  dci_job:
+    id: '{{ job_id }}'
+    embed:
+      - results
+  register: job_results
+  delegate_to: localhost
+
 - name: Send success notification via Slask
   slack:
     token: '{{ slack_token }}'
-    msg: 'Successful run <https://www.distributed-ci.io/#!/jobs/{{ job_id }}/results| [{{ topic }}][{{ platform }}] Successful run>'
+    msg: 'Successful run <https://www.distributed-ci.io/#!/jobs/{{ job_id }}/results| [{{ topic }}][{{ platform }}] Successful run> Total: {{ job_results.job.results[0].total }} - Success {{ job_results.job.results[0].success }} - Skip {{ job_results.job.results[0].skips }} - Error {{ job_results.job.results[0].errors }} - Failure {{ job_results.job.results[0].failures }}'
     channel: '#core_networking_tests'
     parse: none
     color: good


### PR DESCRIPTION
Display the number of failure/skip/error/success in the Slack
notification directly so the user does not have to log into
www.distributed-ci.io to figure out what the numbers are.

Fixes: https://github.com/ansible/dci-partner-ansible/issues/32